### PR TITLE
Changes to allow python-jws to work on Python 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ python-jws
 =====
 A Python implementation of [JSON Web Signatures draft 02](http://self-issued.info/docs/draft-jones-json-web-signature.html)
 
+Also now works on Python 3.3+ as well as Python 2.7+.  However, it's a naive conversion to support both Python 2 and Python 3 so there may well be hidden bugs.
+
 Installing
 ----------
     $ pip install jws

--- a/README.txt
+++ b/README.txt
@@ -2,6 +2,8 @@ python-jws
 =====
 A Python implementation of [JSON Web Signatures draft 02](http://self-issued.info/docs/draft-jones-json-web-signature.html)
 
+Also now works on Python 3.3+ as well as Python 2.7+.  However, it's a naive conversion to support both Python 2 and Python 3 so there may well be hidden bugs.
+
 Installing
 ----------
     $ pip install jws

--- a/jws/__init__.py
+++ b/jws/__init__.py
@@ -1,11 +1,13 @@
+from __future__ import absolute_import
+
 import json
 
-import utils
+import jws.utils as utils
 
 # local
-import algos
-import header
-from exceptions import *
+import jws.algos as algos
+import jws.header as header
+from jws.exceptions import *
 
 ##############
 # public api #

--- a/jws/algos.py
+++ b/jws/algos.py
@@ -1,6 +1,10 @@
+from __future__ import absolute_import
+
+import sys
 import re
 
-from exceptions import SignatureError, RouteMissingError, RouteEndpointError
+from .exceptions import SignatureError, RouteMissingError, RouteEndpointError
+from .utils import to_bytes_2and3
 
 class AlgorithmBase(object):
     """Base for algorithm support classes."""
@@ -31,7 +35,11 @@ class HMAC(HasherBase):
     """
     def sign(self, msg, key):
         import hmac
-        utfkey = unicode(key).encode('utf8')
+        if sys.version < '3':
+            utfkey = unicode(key).encode('utf8')
+        else:
+            utfkey = to_bytes_2and3(key)
+            msg = to_bytes_2and3(msg)
         return hmac.new(utfkey, msg, self.hasher).digest()
 
     def verify(self, msg, crypto, key):
@@ -60,7 +68,7 @@ class RSABase(HasherBase):
         """
         import Crypto.PublicKey.RSA as RSA
 
-        self.hashm.update(msg)
+        self.hashm.update(msg.encode('UTF-8'))
         ## assume we are dealing with a real key
         # private_key = RSA.importKey(key)
         return self.padder.new(key).sign(self.hashm)             # pycrypto 2.5
@@ -74,7 +82,7 @@ class RSABase(HasherBase):
         """
         import Crypto.PublicKey.RSA as RSA
 
-        self.hashm.update(msg)
+        self.hashm.update(msg.encode('UTF-8'))
         private_key = key
         if not isinstance(key, RSA._RSAobj):
             private_key = RSA.importKey(key)
@@ -113,6 +121,7 @@ class ECDSA(HasherBase):
         ##  assume the signing key is already a real key
         # curve = getattr(ecdsa, self.bits_to_curve[self.bits])
         # signing_key = ecdsa.SigningKey.from_string(key, curve=curve)
+        msg = to_bytes_2and3(msg)
         return key.sign(msg, hashfunc=self.hasher)
 
     def verify(self, msg, crypto, key):
@@ -128,7 +137,7 @@ class ECDSA(HasherBase):
         if not isinstance(vk, ecdsa.VerifyingKey):
             vk = ecdsa.VerifyingKey.from_string(key, curve=curve)
         try:
-            vk.verify(crypto, msg, hashfunc=self.hasher)
+            vk.verify(crypto, to_bytes_2and3(msg), hashfunc=self.hasher)
         except ecdsa.BadSignatureError:
             raise SignatureError("Could not validate signature")
         except AssertionError:
@@ -147,25 +156,25 @@ def find(name):
         if match:
             return (endpoint, match)
     raise RouteMissingError('endpoint matching %s could not be found' % name)
-    
+
 def resolve(endpoint, match):
     if callable(endpoint):
         # send result back through
         return resolve(endpoint(**match.groupdict()), match)
-    
+
     # get the sign and verify methods from dict or obj
     try:
         crypt = { 'sign': endpoint['sign'], 'verify': endpoint['verify'] }
     except TypeError:
         try:
             crypt = { 'sign': endpoint.sign, 'verify': endpoint.verify }
-        except AttributeError, e:
+        except AttributeError as e:
             raise RouteEndpointError('route enpoint must have sign, verify as attributes or items of dict')
     # verify callability
     try:
         assert callable(crypt['sign'])
         assert callable(crypt['verify'])
-    except AssertionError, e:
+    except AssertionError as e:
         raise RouteEndpointError('sign, verify of endpoint must be callable')
     return crypt
 

--- a/jws/header.py
+++ b/jws/header.py
@@ -1,5 +1,9 @@
-import algos
-from exceptions import AlgorithmNotImplemented, ParameterNotImplemented, ParameterNotUnderstood, RouteMissingError
+from __future__ import absolute_import
+
+import jws.algos as algos
+
+from .exceptions import AlgorithmNotImplemented, ParameterNotImplemented, ParameterNotUnderstood, RouteMissingError
+
 class HeaderBase(object):
     def __init__(self, name, value, data):
         self.name = name
@@ -29,9 +33,9 @@ class Algorithm(HeaderBase):
     def clean(self, value):
         try:
             self.methods = algos.route(value)
-        except RouteMissingError, e:
+        except RouteMissingError as e:
             raise AlgorithmNotImplemented('"%s" not implemented.' % value)
-    
+
     def sign(self):
         self.data['signer'] = self.methods['sign']
     def verify(self):
@@ -40,15 +44,15 @@ class Algorithm(HeaderBase):
 KNOWN_HEADERS = {
     # REQUIRED, signing algo, see signing_methods
     'alg': Algorithm,
-    # OPTIONAL, type of signed content         
+    # OPTIONAL, type of signed content
     'typ': GenericString,
     # OPTIONAL, JSON Key URL. See http://self-issued.info/docs/draft-jones-json-web-key.html
     'jku': VerifyNotImplemented,
-     # OPTIONAL, key id, hint for which key to use.    
+     # OPTIONAL, key id, hint for which key to use.
     'kid': VerifyNotImplemented,
     # OPTIONAL, x.509 URL pointing to certificate or certificate chain
     'x5u': VerifyNotImplemented,
-    # OPTIONAL, x.509 certificate thumbprint    
+    # OPTIONAL, x.509 certificate thumbprint
     'x5t': VerifyNotImplemented,
 }
 

--- a/jws/tests.py
+++ b/jws/tests.py
@@ -1,5 +1,5 @@
 import unittest
-import jws 
+import jws
 import ecdsa
 import hashlib
 import Crypto.PublicKey.RSA as rsa
@@ -10,9 +10,11 @@ class TestJWS_helpers(unittest.TestCase):
                  ('RS256', jws.algos.RSA_PKCS1_5), ('RS384', jws.algos.RSA_PKCS1_5), ('RS512', jws.algos.RSA_PKCS1_5),
                  ('PS256', jws.algos.RSA_PSS),     ('PS384', jws.algos.RSA_PSS),     ('PS512', jws.algos.RSA_PSS),
                  ('HS256', jws.algos.HMAC),        ('HS384', jws.algos.HMAC),        ('HS512', jws.algos.HMAC)]
-                
-        map(lambda (name, fn): self.assertIn(fn, jws.algos.find(name)), names)
-    
+
+        # map(lambda (name, fn): self.assertIn(fn, jws.algos.find(name)), names)
+        # Python 3+ support (no tuple unpacking)
+        map(lambda name_fn: self.assertIn(name_fn[1], jws.algos.find(name_fn[0])), names)
+
     def test_bad_algorithm_route(self):
         self.assertRaises(jws.algos.RouteMissingError, jws.algos.route, 'f7u12')
 
@@ -26,7 +28,7 @@ class TestJWS_helpers(unittest.TestCase):
         jws.header.process(data, 'sign')
         self.assertIn('signer', data)
         self.assertTrue(callable(data['signer']))
-        
+
         # make sure algo can actually sign
         sk256 = ecdsa.SigningKey.generate(ecdsa.NIST256p)
         found = data['signer']
@@ -35,7 +37,7 @@ class TestJWS_helpers(unittest.TestCase):
     def test_header_algo_missing(self):
         header = {'alg': 'f7u12'}
         self.assertRaises(jws.header.AlgorithmNotImplemented, jws.header.process, {'header':header}, 'sign')
-    
+
     def test_header_param_not_implemented(self):
         header = {'something': "i don't understand"}
         self.assertRaises(jws.header.ParameterNotUnderstood, jws.header.process, {'header':header}, 'sign')
@@ -48,56 +50,60 @@ class TestJWS_helpers(unittest.TestCase):
         data = {'header': header}
         jws.header.process(data, 'sign')
         self.assertEqual(data['key'], 'somethingelse')
-        
+
     def test_custom_algorithm(self):
         class F7U12(jws.algos.AlgorithmBase):
             def __init__(self): pass
             def sign(self, msg, key):
                 return 'u mad?' + key
             def verify(self, msg, sig, key):
-                if sig == 'u mad?' + key: return '<trollface>'
+                import sys
+                if sys.version < '3':
+                    if sig == 'u mad?' + key: return '<trollface>'
+                else:
+                    if sig == b'u mad?' + bytes(key, 'UTF-8'): return '<trollface>'
                 raise jws.SignatureError('Y U NO GIVE GOOD SIGNATURE')
         jws.algos.CUSTOM = [ ('F7U12',  F7U12) ]
         header = {'alg': 'F7U12'}
         payload = {'some': 'claim'}
-        
+
         sig = jws.sign(header, payload, 'wutlol')
         self.assertEqual(jws.verify(header,payload,sig, 'wutlol'), '<trollface>')
         self.assertRaises(jws.SignatureError, jws.verify, header, payload, sig, 'raaaaage')
-        
+
 
 class TestJWS_ecdsa(unittest.TestCase):
     sk256 = ecdsa.SigningKey.generate(ecdsa.NIST256p)
     sk384 = ecdsa.SigningKey.generate(ecdsa.NIST384p)
     sk512 = ecdsa.SigningKey.generate(ecdsa.NIST521p) # yes, 521
-    
+
     def setUp(self):
         self.payload = {
             'whine': {'luke': 'But I was going into Tosche station to pick up some power converters!'},
             'rebuttal': {'owen': "You can waste time with your friends when you're done with your chores."},
         }
-    
+
     def test_valid_ecdsa256(self):
         key = self.sk256
         header = {'alg': 'ES256'}
         sig = jws.sign(header, self.payload, key)
         self.assertTrue(len(sig) > 0)
         self.assertTrue(jws.verify(header, self.payload, sig, key.get_verifying_key()))
-    
+
     def test_valid_ecdsa384(self):
         key = self.sk384
         header = {'alg': 'ES384'}
         sig = jws.sign(header, self.payload, key)
         self.assertTrue(len(sig) > 0)
         self.assertTrue(jws.verify(header, self.payload, sig, key.get_verifying_key()))
-    
+
     def test_valid_ecdsa512(self):
         key = self.sk512
         header = {'alg': 'ES512'}
         sig = jws.sign(header, self.payload, key)
         self.assertTrue(len(sig) > 0)
         self.assertTrue(jws.verify(header, self.payload, sig, key.get_verifying_key()))
-        
+
     def test_invalid_ecdsa_decode(self):
         header = {'alg': 'ES256'}
         sig = jws.sign(header, self.payload, self.sk256)
@@ -107,26 +113,26 @@ class TestJWS_ecdsa(unittest.TestCase):
         self.assertRaises(jws.SignatureError, jws.verify, header, {'bad':1}, sig, vk)
         self.assertRaises(jws.SignatureError, jws.verify, header, {'bad':1}, sig, badkey)
 
-        
+
 class TestJWS_hmac(unittest.TestCase):
     def setUp(self):
         self.payload = {
             'whine': {'luke': 'But I was going into Tosche station to pick up some power converters!'},
             'rebuttal': {'owen': "You can waste time with your friends when you're done with your chores."},
         }
-    
+
     def test_valid_hmac256(self):
         header = {'alg': 'HS256'}
         sig = jws.sign(header, self.payload, 'secret')
         self.assertTrue(len(sig) > 0)
         self.assertTrue(jws.verify(header, self.payload, sig, 'secret'))
-    
+
     def test_valid_hmac384(self):
         header = {'alg': 'HS384'}
         sig = jws.sign(header, self.payload, 'secret')
         self.assertTrue(len(sig) > 0)
         self.assertTrue(jws.verify(header, self.payload, sig, 'secret'))
-    
+
     def test_valid_hmac512(self):
         header = {'alg': 'HS512'}
         sig = jws.sign(header, self.payload, 'secret')
@@ -145,7 +151,7 @@ class TestJWS_rsa(unittest.TestCase):
             'whine': {'luke': 'But I was going into Tosche station to pick up some power converters!'},
             'rebuttal': {'owen': "You can waste time with your friends when you're done with your chores."},
         }
-        
+
     def test_valid_rsa256_pkcs1_5(self):
         header = {'alg': 'RS256'}
         sig = jws.sign(header, self.payload, self.private)

--- a/jws/utils.py
+++ b/jws/utils.py
@@ -1,11 +1,27 @@
+from __future__ import unicode_literals
+
 import base64
 import json
 
+import sys
+if sys.version < '3':
+    text_type = unicode
+    binary_type = str
+else:
+    text_type = str
+    binary_type = bytes
+
+def to_bytes_2and3(s):
+    if type(s) != binary_type:
+        s = bytes(s, 'UTF-8')
+    return s
+
 def base64url_decode(input):
-    input += '=' * (4 - (len(input) % 4))
+    input = to_bytes_2and3(input)
+    input += b'=' * (4 - (len(input) % 4))
     return base64.urlsafe_b64decode(input)
 def base64url_encode(input):
-    return base64.urlsafe_b64encode(input).replace('=', '')
+    return base64.urlsafe_b64encode(to_bytes_2and3(input)).replace(b'=', b'')
 
 def to_json(a): return json.dumps(a)
 def from_json(a): return json.loads(a)

--- a/setup.py
+++ b/setup.py
@@ -20,4 +20,5 @@ setup(
         "Topic :: Utilities",
         "License :: OSI Approved :: MIT License",
     ],
+    test_suite = 'nose.collector',
 )


### PR DESCRIPTION
I've tested it on Python 2.7.x and Python 3.3+.  I did the changes so I could use python-jwt but in the end I went with PyJWT instead.  However, since I did the changes, I thought I'd offer them up to you if you'd like them included.