### PR TITLE
Fix TypeError with format string

### DIFF
--- a/examples/minijwt.py
+++ b/examples/minijwt.py
@@ -1,11 +1,11 @@
 import jws
 def to_jwt(claim, algo, key):
     header = {'typ': 'JWT', 'alg': algo}
-    return "%s.%s.%s" % [
+    return '.'.join([
         jws.utils.encode(header),
         jws.utils.encode(claim),
         jws.sign(header, claim, key)
-    ]
+    ])
 def from_jwt(jwt, key):
     (header, claim, sig) = jwt.split('.')
     header = jws.utils.decode(header)


### PR DESCRIPTION
The '%s.%s.%s' was giving me a 'not enough arguments for format string' TypeError, so I switched it to use string join instead.  It would be equally good to use a tuple instead of a list for the list of format parameters.
