### PR TITLE
Verify the input JSON, don't re-gen it

### DIFF
--- a/examples/minijwt.py
+++ b/examples/minijwt.py
@@ -7,9 +7,10 @@ def to_jwt(claim, algo, key):
         jws.sign(header, claim, key)
     ])
 def from_jwt(jwt, key):
+    "Returns the decoded claim on success, or throws exception on error"
     (header, claim, sig) = jwt.split('.')
-    header = jws.utils.decode(header)
-    claim = jws.utils.decode(claim)
-    jws.verify(header, claim, sig, key)
-    return claim
+    header = jws.utils.from_base64(header)
+    claim = jws.utils.from_base64(claim)
+    jws.verify(header, claim, sig, key, is_json=True)
+    return jws.utils.from_json(claim)
 


### PR DESCRIPTION
Python dict keys are in an undefined order, which means json.dumps()
doesn't reliably produce the same string.  So in JWT, it's best to
verify the input JSON, rather than decoding it, re-encoding it, and
verifying it.  Otherwise you get spurious verification failures.