### PR TITLE
Fix constant time comparison

### DIFF
--- a/jws/utils.py
+++ b/jws/utils.py
@@ -31,20 +31,37 @@ def encode(a): return to_base64(to_json(a))
 def decode(a): return from_json(from_base64(a))
 
 #Taken from Django Source Code
+if binary_type == str:
+    def constant_time_compare(val1, val2):
+        """
+        Returns True if the two strings are equal, False otherwise.
 
-def constant_time_compare(val1, val2):
-    """
-    Returns True if the two strings are equal, False otherwise.
+        The time taken is independent of the number of characters that match.
 
-    The time taken is independent of the number of characters that match.
+        For the sake of simplicity, this function executes in constant time only
+        when the two strings have the same length. It short-circuits when they
+        have different lengths.
+        """
+        if len(val1) != len(val2):
+            return False
+        result = 0
+        for x, y in zip(val1, val2):
+            result |= ord(x) ^ ord(y)
+        return result == 0
+else:
+    def constant_time_compare(val1, val2):
+        """
+        Returns True if the two strings are equal, False otherwise.
 
-    For the sake of simplicity, this function executes in constant time only
-    when the two strings have the same length. It short-circuits when they
-    have different lengths.
-    """
-    if len(val1) != len(val2):
-        return False
-    result = 0
-    for x, y in zip(val1, val2):
-        result |= ord(x) ^ ord(y)
-    return result == 0
+        The time taken is independent of the number of characters that match.
+
+        For the sake of simplicity, this function executes in constant time only
+        when the two strings have the same length. It short-circuits when they
+        have different lengths.
+        """
+        if len(val1) != len(val2):
+            return False
+        result = 0
+        for x, y in zip(val1, val2):
+            result |= x ^ y
+        return result == 0


### PR DESCRIPTION
Update utils.py to define two different constant time comparisons; one which is appropriate for use w/ Python2 and one which is appropriate for use with Python3.  Unit tests were previously failing on python3, and no longer fail with this update.

The algorithm is the same between the two of them, differing in the use of ord(), which fails on ints which are present in python3 when iterating over the bytes class.  This fixes #19.