### PR TITLE
Fixes error when attempting to install with Python 3.5.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 import os
 from setuptools import setup
 
+
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return open(os.path.join(os.path.dirname(__file__), fname), encoding='utf-8').read()
 
 setup(
     name = "jws",


### PR DESCRIPTION
```
# pip install jws
Collecting jws
  Downloading jws-0.1.3.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-4smf5vyz/jws/setup.py", line 17, in <module>
        long_description=read('README.md'),
      File "/tmp/pip-build-4smf5vyz/jws/setup.py", line 5, in read
        return open(os.path.join(os.path.dirname(__file__), fname)).read()
      File "/opt/venv/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 500: ordinal not in range(128)
```
