### PR TITLE
ASCII Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,22 +15,22 @@ Algorithms
 The JWS spec reserves several algorithms for cryptographic signing. Out of the 9, this library currently supports 7:
 
 
-**HMAC** – native
+**HMAC** -- native
 
-* HS256 – HMAC using SHA-256 hash algorithm
-* HS384 – HMAC using SHA-384 hash algorithm
-* HS512 – HMAC using SHA-512 hash algorithm
+* HS256 -- HMAC using SHA-256 hash algorithm
+* HS384 -- HMAC using SHA-384 hash algorithm
+* HS512 -- HMAC using SHA-512 hash algorithm
 
 
-**RSA** – requires pycrypto >= 2.5: ``pip install pycrypto``
+**RSA** -- requires pycrypto >= 2.5: ``pip install pycrypto``
 
-* RS256 – RSA using SHA-256 hash algorithm
+* RS256 -- RSA using SHA-256 hash algorithm
 
-**ECDSA** – requires ecdsa lib: ``pip install ecdsa``
+**ECDSA** -- requires ecdsa lib: ``pip install ecdsa``
 
-* ES256 – ECDSA using P-256 curve and SHA-256 hash algorithm
-* ES384 – ECDSA using P-384 curve and SHA-384 hash algorithm
-* ES512 – ECDSA using P-521 curve and SHA-512 hash algorithm
+* ES256 -- ECDSA using P-256 curve and SHA-256 hash algorithm
+* ES384 -- ECDSA using P-384 curve and SHA-384 hash algorithm
+* ES512 -- ECDSA using P-521 curve and SHA-512 hash algorithm
 
 There is also a mechanism for extending functionality by adding your own
 algorithms without cracking open the whole codebase. See the advanced usage


### PR DESCRIPTION
Currently setup.py pulls in the long description from the README.md: `(long_description=read('README.md')`

Sadly, because you have unicode emdashes ("\xe2\x80\x93" instead of "--") in the readme.md python will fail trying to stringify those characters and error with:

```
Collecting jws>=0.1.3 (from python_jwt==1.1.0->-r /tmp/tmpEbDt97/requirements.txt (line 27))
  Downloading jws-0.1.3.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-db5dsmc7/jws/setup.py", line 17, in <module>
        long_description=read('README.md'),
      File "/tmp/pip-build-db5dsmc7/jws/setup.py", line 5, in read
        return open(os.path.join(os.path.dirname(__file__), fname)).read()
      File "/venv3/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 500: ordinal not in range(128)
```

To reproduce, under Python 3.5 run: `LC_CTYPE=C pip3 install jws`

This fixes this, but it would require a subsequent point release (0.1.4) to actually to keep it from happening on future pip installs.
