### PR TITLE
fixed python 3 interpolation bug in _signing_input

### DIFF
--- a/jws/__init__.py
+++ b/jws/__init__.py
@@ -53,4 +53,4 @@ def verify(head, payload, encoded_signature, key=None, is_json=False):
 def _signing_input(head, payload, is_json=False):
     enc = utils.to_base64 if is_json else utils.encode
     head_input, payload_input = map(enc, [head, payload])
-    return "%s.%s" % (head_input, payload_input)
+    return b".".join([head_input, payload_input])


### PR DESCRIPTION
I noticed differences comparing the signatures for the same objects in Python 2.6 and 3.5, It's because the  interpolation of "%s.%s" in _signing_input causes the string to add the type specifier (b''). Changing to a join fixes the issue.