### PR TITLE
Proper support for 'kid' header.

### DIFF
--- a/jws/__init__.py
+++ b/jws/__init__.py
@@ -26,7 +26,7 @@ def sign(head, payload, key=None, is_json=False):
     if not data['signer']:
         raise MissingSigner("Header was processed, but no algorithm was found to sign the message")
     signer = data['signer']
-    signature = signer(_signing_input(head, payload, is_json), key)
+    signature = signer(_signing_input(head, payload, is_json), data['key'])
     return utils.to_base64(signature)
 
 
@@ -45,7 +45,7 @@ def verify(head, payload, encoded_signature, key=None, is_json=False):
         raise MissingVerifier("Header was processed, but no algorithm was found to sign the message")
     verifier = data['verifier']
     signature = utils.from_base64(encoded_signature)
-    return verifier(_signing_input(head, payload, is_json), signature, key)
+    return verifier(_signing_input(head, payload, is_json), signature, data['key'])
 
 ####################
 # semi-private api #


### PR DESCRIPTION
Problem: Setting data['key'] in header handlers has no effect.

Solution: Pass data['key'] as it appears after processing the headers.