### PR TITLE
Fix 'cp949' decode error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return open(os.path.join(os.path.dirname(__file__), fname), encoding="UTF-8").read()
 
 setup(
     name = "jws",


### PR DESCRIPTION
Because of this error, I couldn't install 'python-jws' on Windows.