### PR TITLE
docs: fix simple typo, implemention -> implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Other Stuff
 
 Check out
 https://github.com/brianloveswords/python-jws/blob/master/examples/minijwt.py
-for a 14-line implemention of JWT.
+for a 14-line implementation of JWT.
 
 See
 https://github.com/brianloveswords/python-jws/blob/master/examples/ragecrypto.py


### PR DESCRIPTION
There is a small typo in README.md.

Should read `implementation` rather than `implemention`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md